### PR TITLE
fix: Update package version to fix deployment

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brown-ccv/eslint-config",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "keywords": [
     "eslint",
     "eslintconfig"


### PR DESCRIPTION
The `@brown-ccv/eslint-config` peer dependencies were correct in the repo but didn't seem to be published. Updated the version to 0.3.1 and published the package.